### PR TITLE
Optimize Autoclick

### DIFF
--- a/AHK/src/apexmaster.ahk
+++ b/AHK/src/apexmaster.ahk
@@ -10,7 +10,7 @@ SetBatchLines, -1
 ListLines Off
 SetWorkingDir %A_ScriptDir%
 SetKeyDelay, -1, -1
-SetMouseDelay, -1
+SetMouseDelay, 40
 SetDefaultMouseSpeed, 0
 SetWinDelay, -1
 SetControlDelay, -1


### PR DESCRIPTION
Setting the mouse delay to 40ms can solve the problem of Autoclick jamming without affecting usage